### PR TITLE
tirar a margem esquerda gigante para melhorar a visualização de resultados

### DIFF
--- a/app/views/layouts/blazer/application.html.erb
+++ b/app/views/layouts/blazer/application.html.erb
@@ -18,7 +18,7 @@
     <%= csrf_meta_tags %>
   </head>
   <body>
-    <div class="container">
+    <div class="container" style="margin-left:40px">
       <%= yield %>
     </div>
   </body>


### PR DESCRIPTION
tirar a margem esquerda gigante para melhorar a visualização de resultado